### PR TITLE
[WIP] Improves handling of existing k8s jobs on restart of Galaxy

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -218,6 +218,15 @@
                  zero (no execution) and the stderr/stdout of the k8s job is reported in galaxy (and the galaxy job set
                  to failed) -->
 
+            <!-- <param id="k8s_galaxy_instance_id">my-instance</param> -->
+            <!-- Identifies the Galaxy instance where this runner belongs. Setting this variable means that the runner
+                 will trust k8s Jobs with the structure galaxy-my-instance-<number> to be its own. This variable needs
+                 to be DNS friendly, and up to 20 characters, as it will go in the k8s Jobs and Pods names. An instance
+                 in this context is understood as a running Galaxy setup that is bound to a particular database stored
+                 state. This is mostly relevant for long term running instances. When resetting a long term running
+                 instance to zero (database and files deleted), one would want to change this instance id to avoid
+                 clashing with previous jobs in the same k8s cluster where the older setup run. -->
+
             <!-- <param id="k8s_supplemental_group_id">0</param> -->
             <!-- <param id="k8s_fs_group_id">0</param> -->
             <!-- If mounting an NFS / GlusterFS or other shared file system which is administered to ONLY provide access

--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -227,6 +227,13 @@
                  instance to zero (database and files deleted), one would want to change this instance id to avoid
                  clashing with previous jobs in the same k8s cluster where the older setup run. -->
 
+            <!-- <param id="k8s_timeout_seconds_job_deletion">30</param> -->
+            <!-- If the above `k8s_galaxy_instance_id` is not set, when finding an existing k8s job with the same
+                 id as a new job being generated, the runner will attempt to delete that existing job first, to proceed
+                 then to create the new job (the old job is not trusted to have been instructed to do the same as the
+                 new one). This variables controls the timeout for waiting for that job deletion. If the timeout is
+                 exceeded and the existing job is not deleted, the new job won't be added to the Galaxy queue. -->
+
             <!-- <param id="k8s_supplemental_group_id">0</param> -->
             <!-- <param id="k8s_fs_group_id">0</param> -->
             <!-- If mounting an NFS / GlusterFS or other shared file system which is administered to ONLY provide access

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -4,6 +4,7 @@ Offload jobs to a Kubernetes cluster.
 
 import logging
 import re
+from time import sleep
 from os import environ as os_environ
 
 from six import text_type
@@ -49,6 +50,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_persistent_volume_claim_name=dict(map=str),
             k8s_persistent_volume_claim_mount_path=dict(map=str),
             k8s_namespace=dict(map=str, default="default"),
+            k8s_galaxy_instance_id=dict(map=str),
             k8s_job_api_version=dict(map=str, default="batch/v1"),
             k8s_supplemental_group_id=dict(map=str),
             k8s_pull_policy=dict(map=str, default="Default"),
@@ -73,6 +75,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         else:
             self._pykube_api = HTTPClient(KubeConfig.from_file(self.runner_params["k8s_config_path"]))
         self._galaxy_vol_name = "pvc-galaxy"  # TODO this needs to be read from params!!
+
+        self._galaxy_instance_id = self.__get_galaxy_instance_id()
 
         self._supplemental_group = self.__get_supplemental_group()
         self._fs_group = self.__get_fs_group()
@@ -107,15 +111,25 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             "spec": self.__get_k8s_job_spec(job_wrapper)
         }
 
-        # Checks if job exists
+        # Checks if job exists and is trusted, or if it needs re-creation.
         job = Job(self._pykube_api, k8s_job_obj)
-        if job.exists():
+        if job.exists() and not self._galaxy_instance_id:
+            # if galaxy instance id is not set, then we don't trust matching jobs and we simply delete and
+            # re-create the job
+            log.debug("Matching job exists, but Job is not trusted, so it will be deleted and a new one created.")
             job.delete()
-        # Creates the Kubernetes Job
-        # TODO if a job with that ID exists, what should we do?
-        # TODO do we trust that this is the same job and use that?
-        # TODO or create a new job as we cannot make sure
-        Job(self._pykube_api, k8s_job_obj).create()
+            while job.exists():
+                sleep(3)
+                log.debug("Waiting for job to be deleted "+k8s_job_name)
+            Job(self._pykube_api, k8s_job_obj).create()
+        elif job.exists() and self._galaxy_instance_id:
+            # The job exists and we trust the identifier.
+            log.debug("Matching job exists, but Job is trusted, so we simply use the existing one for "+k8s_job_name)
+            # We simply leave the k8s job to be handled later on by the check watched-items.
+        else:
+            # Creates the Kubernetes Job if it doesn't exist.
+            job.create()
+
 
         # define job attributes in the AsyncronousJobState for follow-up
         ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper,
@@ -152,9 +166,34 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 return None
         return None
 
+    def __get_galaxy_instance_id(self):
+        """
+        Gets the id of the Galaxy instance. This will be added to Jobs and Pods names, so it needs to be DNS friendly,
+        this means: `The Internet standards (Requests for Comments) for protocols mandate that component hostname labels
+        may contain only the ASCII letters 'a' through 'z' (in a case-insensitive manner), the digits '0' through '9',
+        and the minus sign ('-').`
+
+        It looks for the value set on self.runner_params['k8s_galaxy_instance_id'], which might or not be set. The
+        idea behind this is to allow the Galaxy instance to trust (or not) existing k8s Jobs and Pods that match the
+        setup of a Job that is being recovered or restarted after a downtime/reboot.
+        :return:
+        :rtype:
+        """
+        if "k8s_galaxy_instance_id" in self.runner_params:
+            if re.match("(?!-)[a-z\d-]{1,20}(?<!-)$", self.runner_params['k8s_galaxy_instance_id']):
+                return self.runner_params['k8s_galaxy_instance_id']
+            else:
+                log.error("Galaxy instance '"+self.runner_params['k8s_galaxy_instance_id']+"' is either too long "
+                            + "(>20 characters) or it includes non DNS acceptable characters, ignoring it.")
+        return None
+
+
     def __produce_unique_k8s_job_name(self, galaxy_internal_job_id):
         # wrapper.get_id_tag() instead of job_id for compatibility with TaskWrappers.
-        return "galaxy-" + galaxy_internal_job_id
+        instance_id = ""
+        if self._galaxy_instance_id and len(self._galaxy_instance_id) > 0:
+            instance_id = self._galaxy_instance_id + "-"
+        return "galaxy-" + instance_id + galaxy_internal_job_id
 
     def __get_k8s_job_spec(self, job_wrapper):
         """Creates the k8s Job spec. For a Job spec, the only requirement is to have a .spec.template."""
@@ -524,6 +563,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         """Recovers jobs stuck in the queued/running state when Galaxy started"""
         # TODO this needs to be implemented to override unimplemented base method
         job_id = job.get_job_runner_external_id()
+        log.debug("k8s trying to recover job: "+job_id)
         if job_id is None:
             self.put(job_wrapper)
             return

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -51,6 +51,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_persistent_volume_claim_mount_path=dict(map=str),
             k8s_namespace=dict(map=str, default="default"),
             k8s_galaxy_instance_id=dict(map=str),
+            k8s_timeout_seconds_job_deletion=dict(map=int, valid=lambda x: int > 0, default=30),
             k8s_job_api_version=dict(map=str, default="batch/v1"),
             k8s_supplemental_group_id=dict(map=str),
             k8s_pull_policy=dict(map=str, default="Default"),
@@ -118,9 +119,15 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             # re-create the job
             log.debug("Matching job exists, but Job is not trusted, so it will be deleted and a new one created.")
             job.delete()
+            elapsed_seconds = 0
             while job.exists():
                 sleep(3)
-                log.debug("Waiting for job to be deleted "+k8s_job_name)
+                elapsed_seconds += 3
+                if elapsed_seconds > self.runner_params['k8s_timeout_seconds_job_deletion']:
+                    log.debug("Timed out before k8s could delete existing untrusted job " + k8s_job_name +
+                              ", not queuing associated Galaxy job.")
+                    return
+                log.debug("Waiting for job to be deleted " + k8s_job_name)
             Job(self._pykube_api, k8s_job_obj).create()
         elif job.exists() and self._galaxy_instance_id:
             # The job exists and we trust the identifier.


### PR DESCRIPTION
… with jobs of previous instances, establishing an optional trust mechanism.

This PR establishes an optional mechanism by which the k8s runner can trust matching Jobs existing in the Kubernetes cluster. Normally this issue is encountered when the Galaxy instance is restarted and it goes through the previously existing Galaxy/k8s jobs. Before this PR this event generated the following error:

```
galaxy.jobs.runners ERROR 2017-11-10 17:27:46,959 (713) Unhandled exception calling queue_job
Traceback (most recent call last):
  File "/galaxy/lib/galaxy/jobs/runners/__init__.py", line 104, in run_next
    method(arg)
  File "/galaxy/lib/galaxy/jobs/runners/kubernetes.py", line 118, in queue_job
    Job(self._pykube_api, k8s_job_obj).create()
  File "/galaxy/.venv/local/lib/python2.7/site-packages/pykube/objects.py", line 97, in create
    self.api.raise_for_status(r)
  File "/galaxy/.venv/local/lib/python2.7/site-packages/pykube/http.py", line 106, in raise_for_status
    raise HTTPError(resp.status_code, payload["message"])
HTTPError: object is being deleted: jobs.batch "galaxy-713" already exists
```

Now the runner, even when not trusting the jobs in the cluster, takes adequate measures to avoid this issue: it waits until the job has been actually deleted to re-create it.

When the job is trusted, nothing is done to the job at the queue level, and is left to be monitored as any other job by the `check_watched_items`.

Trust mechanism is based on the admin defining an arbitrary `galaxy_instance_id`, which is added to the job/pods name on creation. When such instance_id is set, then all jobs/pods with that id in their name (and proper structure) will be trusted to have been created by that same Galaxy instance (before restarting) and they won't be deleted and re-created (but continue to be monitored for completion).

This is mostly relevant for long term running instances, and shouldn't be used in development environments (or could be used, but with a constantly changing id) or short term lived installations that are not expected to be restarted.
