### PR TITLE
Update isa-rwval version for upstream changes in isa-rwval

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -92,4 +92,4 @@ ecdsa==0.13
 python-genomespaceclient==0.1.8
 
 # ISA
-isa-rwval==0.10.2
+isa-rwval==0.10.3


### PR DESCRIPTION
Updates `isa-rwval` version (upstream change in `isa-rwval` updates `six` dependency) for the PhenoMeNal Galaxy upgrade.