### PR TITLE
Catch IOErrors when the k8s runner tries to collect job logs

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -427,10 +427,14 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
             # This assumes jobs dependent on a single pod, single container
             if succeeded > 0:
-                self.__produce_log_file(job_state)
-                error_file = open(job_state.error_file, 'w')
-                error_file.write("")
-                error_file.close()
+                try:
+                    self.__produce_log_file(job_state)
+                    error_file = open(job_state.error_file, 'w')
+                    error_file.write("")
+                    error_file.close()
+                except IOError as e:
+                    log.error("Couldn't produce log files for %s", job_state.job_id)
+                    log.exception(e)
                 job_state.running = False
                 self.mark_as_finished(job_state)
                 return None
@@ -507,8 +511,13 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         """
 
         # First we rescue the pods logs
-        with open(job_state.output_file, 'r') as outfile:
-            stdout_content = outfile.read()
+        try:
+            with open(job_state.output_file, 'r') as outfile:
+                stdout_content = outfile.read()
+        except IOError as e:
+            stdout_content = "<Failed to recuperate log>"
+            log.error("Failed to get stdout for job %s", job_state.job_id)
+            log.exception(e)
 
         if getattr(job_state, 'stop_job', True):
             self.stop_job(self.sa_session.query(self.app.model.Job).get(job_state.job_wrapper.job_id))


### PR DESCRIPTION
This commit should fix cases where successful job can't be marked as
done by Galaxy because the logs have gone missing.

Tested in minikube.